### PR TITLE
Don't call ExtractionTube.onTick on client-side

### DIFF
--- a/src/schmoller/tubes/types/ExtractionTube.java
+++ b/src/schmoller/tubes/types/ExtractionTube.java
@@ -44,6 +44,9 @@ public class ExtractionTube extends DirectionalBasicTube implements IRedstonePar
 	@Override
 	public void onTick()
 	{
+                if(world().isRemote)
+                        return;
+                
 		if(!mOverflow.isEmpty())
 		{
 			TubeItem item = mOverflow.peekNext();


### PR DESCRIPTION
I hope you don't mind pull requests, and didn't already fix this yourself locally.
